### PR TITLE
Add package.json for npm publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "editscript",
+  "version": "0.3.1",
+  "license": "EPL-1.0",
+  "homepage": "https://github.com/juji-io/editscript",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/juji-io/editscript"
+  },
+  "author": {
+    "name" : "Huaha Yang"
+  },
+  "files": [
+    "src/*"
+  ],
+  "directories": {
+    "lib": "src"
+  }
+}


### PR DESCRIPTION
This library is awesome, as lumo works out of the box.

In my quest to use npm as package manager to lumo libs, I am contributing the
`package.json` file to a bunch of projects.

I hope you are interested, if not let me know, no problem :)

I will also add the project here
https://github.com/anmonteiro/lumo/wiki/Compatible-libraries.