### PR TITLE
Fix boxed math warning

### DIFF
--- a/src/editscript/diff/a_star.cljc
+++ b/src/editscript/diff/a_star.cljc
@@ -34,8 +34,10 @@
   (get-next [this] "Get the next sibling node")
   (set-next [this node] "Set the next sibling node")
   (set-order [this o] "Set the traversal order of this node")
-  (^long get-order [this] "Get the order of this node in traversal")
-  (^long get-size [this] "Get the size of sub-tree, used to estimate cost")
+  #?(:clj  (get-order ^long [this] "Get the order of this node in traversal")
+     :cljs (^number get-order [this] "Get the order of this node in traversal"))
+  #?(:clj  (get-size ^long [this] "Get the size of sub-tree, used to estimate cost")
+     :cljs (^number get-size [this] "Get the size of sub-tree, used to estimate cost"))
   (set-size [this s] "Set the size of sub-tree"))
 
 (deftype Node [^PersistentVector path


### PR DESCRIPTION
Currently, using editscript with `(set! *unchecked-math* :warn-on-boxed)` prints this warning:

```
Boxed math warning, editscript/diff/a_star.cljc:121:20 - call: public static java.lang.Number clojure.lang.Numbers.unchecked_add(java.lang.Object,long).
```

This patch fixed this. Source: https://clojure.org/reference/java_interop#typehints