### PR TITLE
port to cljr, tests succeeed but are 10x slower

### DIFF
--- a/deps-clr.edn
+++ b/deps-clr.edn
@@ -1,0 +1,12 @@
+{:paths ["src"]
+ :deps
+ {io.github.clojure/clr.data.generators {:git/tag "v1.1.0" :git/sha "d25d292"}
+  }
+
+ :aliases
+ {:test
+  {:extra-paths ["test"]
+   :extra-deps {io.github.dmiller/test-runner {:git/tag "v0.5.1clr" :git/sha "814e06f"}
+   io.github.clojure/clr.test.check {:git/tag "v1.1.2"  :git/sha "26f34e6"}}
+   :exec-fn cognitect.test-runner.api/test
+   :exec-args {:dirs ["test"]}}}}

--- a/src/editscript/core.cljc
+++ b/src/editscript/core.cljc
@@ -15,6 +15,8 @@
             [editscript.diff.quick :as q]
             [editscript.diff.a-star :as a])
   #?(:clj (:import [editscript.edit EditScript]
+                   [clojure.lang MapEntry])
+     :cljr (:import [editscript.edit EditScript]
                    [clojure.lang MapEntry])))
 
 (defn diff

--- a/src/editscript/diff/quick.cljc
+++ b/src/editscript/diff/quick.cljc
@@ -16,6 +16,7 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 #?(:clj (set! *unchecked-math* :warn-on-boxed))
+#?(:cljr (set! *warn-on-reflection* true))
 
 (declare diff*)
 

--- a/src/editscript/edit.cljc
+++ b/src/editscript/edit.cljc
@@ -11,7 +11,10 @@
 (ns ^:no-doc editscript.edit
   #?(:clj (:import [clojure.lang PersistentVector IPersistentList IPersistentMap
                     IPersistentSet IPersistentVector MapEntry]
-                   [java.util Map$Entry])))
+                   [java.util Map$Entry])
+	:cljr (:import [clojure.lang PersistentVector IPersistentList IPersistentMap
+                    IPersistentSet IPersistentVector MapEntry]
+                  )))
 
 (defprotocol IEdit
   (auto-sizing [this path value])
@@ -53,9 +56,35 @@
 
      IPersistentSet
      (get-type [_] :set)
-
+ 
      Map$Entry
      (get-type [_] :val)
+
+     MapEntry
+     (get-type [_] :val)
+
+     nil
+     (get-type [_] :val)
+
+     String
+     (get-type [_] :str)
+
+     Object
+     (get-type [_] :val))
+	 
+   :cljr
+   (extend-protocol IType
+     IPersistentList
+     (get-type [_] :lst)
+
+     IPersistentMap
+     (get-type [_] :map)
+
+     IPersistentVector
+     (get-type [_] :vec)
+
+     IPersistentSet
+     (get-type [_] :set)
 
      MapEntry
      (get-type [_] :val)

--- a/src/editscript/patch.cljc
+++ b/src/editscript/patch.cljc
@@ -15,6 +15,7 @@
             [clojure.string :as s]))
 
 #?(:clj (set! *warn-on-reflection* true))
+#?(:cljr (set! *warn-on-reflection* true))
 #?(:clj (set! *unchecked-math* :warn-on-boxed))
 
 (defn vget

--- a/src/editscript/util/common.cljc
+++ b/src/editscript/util/common.cljc
@@ -32,7 +32,9 @@
 
 (defn current-time
   ^long []
-  #?(:clj (System/currentTimeMillis) :cljs (.getTime (js/Date.))))
+  #?(:clj (System/currentTimeMillis) 
+     :cljr (.ToUnixTimeMilliseconds (DateTimeOffset/Now))
+  :cljs (.getTime (js/Date.))))
 
 (defn- vec-edits*
   "Based on 'Wu, S. et al., 1990, An O(NP) Sequence Comparison Algorithm,
@@ -106,7 +108,7 @@
                         [ms ps] (split-with #(= % m) coll)
                         mc      (count ms)
                         pc      (count ps)
-                        delta   (Math/abs (- mc pc))
+                        delta   (#?(:cljr Math/Abs :default Math/abs) (- mc pc))
                         rs      (repeat (- (max mc pc) delta) :r)]
                     (cond
                       (< mc pc) (concat rs (repeat delta p))

--- a/src/editscript/util/index.cljc
+++ b/src/editscript/util/index.cljc
@@ -12,7 +12,8 @@
   (:require [editscript.edit :as e]
             #?(:cljs [goog.math.Long :refer [getMaxValue]]))
   #?(:clj (:import [clojure.lang PersistentVector]
-                   [java.io Writer])) )
+                   [java.io Writer])
+				   :cljr (:import [clojure.lang PersistentVector])) )
 
 ;; indexing
 

--- a/src/editscript/util/pairing.cljc
+++ b/src/editscript/util/pairing.cljc
@@ -11,7 +11,10 @@
 (ns ^:no-doc editscript.util.pairing
   #?(:clj
      (:import [clojure.lang IPersistentStack IPersistentMap IPersistentCollection]
-              [java.io Writer])))
+              [java.io Writer])
+	  :cljr
+     (:import [clojure.lang IPersistentStack IPersistentMap IPersistentCollection]
+              )))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -100,7 +103,45 @@
          (set! map (dissoc map (.-item heap)))
          (set! heap n)
          this)))
+:cljr
+   (deftype PriorityMap [^:unsynchronized-mutable ^HeapNode heap
+                         ^:unsynchronized-mutable map]
+     IPersistentCollection
+     (count [_] (count map))
+     (^IPersistentCollection cons [this e]
+       (let [[item priority] e]
+         (set! map (assoc map item priority))
+         (set! heap (insert heap item priority))
+         this))
+     (empty [this]
+       (set! heap nil)
+       (set! map {})
+       this)
+     (equiv [this o] (identical? this o))
 
+     IPersistentMap
+     (^IPersistentMap assoc [this item priority]
+       (set! map (assoc map item priority))
+       (set! heap (insert heap item priority))
+       this)
+     (^clojure.lang.Associative assoc [this item priority]
+       (set! map (assoc map item priority))
+       (set! heap (insert heap item priority))
+       this)
+     (GetHashCode [_] (hash map))
+     (Equals [this o] (identical? this o))
+     (containsKey [_ item] (contains? map item))
+     (entryAt [_ k] (find map k))
+     (seq [_] (seq map))
+     (without [this item] (dissoc map item) this)
+
+     IPersistentStack
+     (peek [_] [(.-item heap) (.-priority heap)])
+     (pop [this]
+       (let [n (two-pass (get-left heap))]
+         (set! map (dissoc map (.-item heap)))
+         (set! heap n)
+         this)))
    :cljs
    (deftype PriorityMap [^:mutable ^HeapNode heap
                          ^:mutable map]
@@ -115,6 +156,7 @@
          (set! heap (insert heap item priority))
          this))
 
+     IAssociative
      IAssociative
      (-assoc [this item priority]
        (set! map (assoc map item priority))

--- a/test/editscript/core_test.cljc
+++ b/test/editscript/core_test.cljc
@@ -230,17 +230,17 @@
 ;; sample data tests
 
 (def data1 (-> "resources/drawing1.edn"
-               #?(:clj slurp :cljs com/vslurp)
-               #?(:clj read-string :cljs reader/read-string)))
+               #?(:default slurp :cljs com/vslurp)
+               #?(:default read-string :cljs reader/read-string)))
 (def data2 (-> "resources/drawing2.edn"
-               #?(:clj slurp :cljs com/vslurp)
-               #?(:clj read-string :cljs reader/read-string)))
+               #?(:default slurp :cljs com/vslurp)
+               #?(:default read-string :cljs reader/read-string)))
 (def data3 (-> "resources/drawing3.edn"
-               #?(:clj slurp :cljs com/vslurp)
-               #?(:clj read-string :cljs reader/read-string)))
+               #?(:default slurp :cljs com/vslurp)
+               #?(:default read-string :cljs reader/read-string)))
 (def data4 (-> "resources/drawing4.edn"
-               #?(:clj slurp :cljs com/vslurp)
-               #?(:clj read-string :cljs reader/read-string)))
+               #?(:default slurp :cljs com/vslurp)
+               #?(:default read-string :cljs reader/read-string)))
 
 (deftest drawing-sample-test
   (testing "A sample JSON data of a drawing program from https://github.com/justsml/json-diff-performance, converted to edn using https://github.com/peterschwarz/json-to-edn"

--- a/test/editscript/edit_test.cljc
+++ b/test/editscript/edit_test.cljc
@@ -12,6 +12,7 @@
   (:require [editscript.edit :as e]
             [editscript.core :as c]
             #?(:clj [clojure.test :refer [is are deftest ]]
+			   :cljr [clojure.test :refer [is are deftest ]]
                :cljs [cljs.test :refer [is are deftest] :include-macros true])))
 
 (deftest edits-equality-test


### PR DESCRIPTION
This is a port of editscript to support cljr. All tests run and are successful. The tests run currenlty and 0.1x speed (i.e. 10 times slower, I have no idea yet why). The print-method code was not yet ported.

It uses deps.edn for clj and cljr. It depends on having "https://github.com/clojure/clr.core.cli" installed and working.